### PR TITLE
Change the default PROXY_HTTP_MODE to https

### DIFF
--- a/commands/common.go
+++ b/commands/common.go
@@ -4,6 +4,6 @@ const (
 	DEFAULT_DOH_SERVER        = "cloudflare-dns.com"
 	OBLIVIOUS_DOH             = "application/oblivious-dns-message"
 	TARGET_HTTP_MODE          = "https"
-	PROXY_HTTP_MODE           = "http"
+	PROXY_HTTP_MODE           = "https"
 	ODOH_CONFIG_WELLKNOWN_URL = "/.well-known/odohconfigs"
 )


### PR DESCRIPTION
As per the protocol diagram on https://blog.cloudflare.com/oblivious-dns/,
the communication from the client to the proxy is encrypted using HTTPS.
When I was adding ODoH proxying support to my DoH service, I attempted
to test the connection and did not expect the default to be set to HTTP.
I think it would be more intuitive for the default to be HTTPS, as that
is the mode indicated in the diagram, and hopefully the mode which most people
will be using proxies.