### PR TITLE
add odoh accept header, log cli errors, make domains fqdns

### DIFF
--- a/cmd/odoh-client.go
+++ b/cmd/odoh-client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -47,5 +48,7 @@ func main() {
 		CustomAppHelpTemplate:  "",
 		UseShortOptionHandling: false,
 	}
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/commands/common.go
+++ b/commands/common.go
@@ -1,9 +1,10 @@
 package commands
 
 const (
-	DEFAULT_DOH_SERVER        = "cloudflare-dns.com"
-	OBLIVIOUS_DOH             = "application/oblivious-dns-message"
-	TARGET_HTTP_MODE          = "https"
-	PROXY_HTTP_MODE           = "https"
-	ODOH_CONFIG_WELLKNOWN_URL = "/.well-known/odohconfigs"
+	DEFAULT_DOH_SERVER         = "cloudflare-dns.com"
+	DOH_CONTENT_TYPE           = "application/dns-message"
+	OBLIVIOUS_DOH_CONTENT_TYPE = "application/oblivious-dns-message"
+	TARGET_HTTP_MODE           = "https"
+	PROXY_HTTP_MODE            = "https"
+	ODOH_CONFIG_WELLKNOWN_URL  = "/.well-known/odohconfigs"
 )


### PR DESCRIPTION
Summary of changes:

- added `Accept: application/oblivious-dns-message` HTTP header to odoh client. I know it's still a draft, but that's what it says clients SHOULD do (see [section 4.1](https://tools.ietf.org/html/draft-pauly-dprive-oblivious-doh-04#section-4.1)).
- log errors returned from `app.Run()`
- automatically make domains fqdns

I also did a bit of code cleanup, mostly involving stuff in commands/common.go and changing `errors.New(fmt.Sprintf())` to `fmt.Errorf()` in commands/request.go.