### PR TITLE
Updating and making it easier to run benchmark measurements for ODoH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dataset/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ VERSION=$(shell cat VERSION)
 
 NAME=odoh-client
 
+DIRS_NEEDED=dataset
+FILENAME="dataset/tranco-1m.zip"
+
 all: clean build
 
 clean:
@@ -15,7 +18,12 @@ build: clean
 	@echo "Version: $(VERSION)"
 	@go build -ldflags "-X main.Version=$(VERSION) -X main.CommitId=$(COMMIT_ID)" ./cmd/*
 
+fetch:
+	@echo "Create the necessary directories ..."
+	chmod +x ./fetch-datasets.sh
+	./fetch-datasets.sh
+
 install:
 	@go install -ldflags "-X main.Version=$(VERSION) -X main.CommitId=$(COMMIT_ID)" ./cmd/*
 
-.PHONY: all clean build install
+.PHONY: all clean build fetch install

--- a/README.md
+++ b/README.md
@@ -40,6 +40,34 @@ go build -o odoh-client ./cmd/...
 ./odoh-client odohconfig-fetch --target odoh.cloudflare-dns.com --pretty
 ```
 
+### Running benchmarks
+
+#### Obtaining a dataset
+
+We use the Tranco Top Million dataset as an example dataset for this repository. The file `fetch-datasets.sh` retrieves
+a sample Tranco top million dataset which is then parsed to remove the ranking numbers modifying the dataset file to
+contain only the hostnames. Any other dataset which follows the same pattern can be directly used as a test file for 
+benchmarking `ODoH`. By running the `make fetch` command, a new directory called `dataset/` is created and the tranco
+top million file is obtained and stored.
+
+```
+make fetch
+```
+
+#### Running the Benchmark
+
+`odoh-client` takes in the path to the dataset `--data` and reads the list, shuffles it to obtain a random order and 
+performs the `ODoH` queries to a chosen `--target` and `--proxy`. By default if the `--out` is not specified, the output
+is printed to console or is written to the file provided in the `--out` argument.
+
+For reading the current defaults and additional configuration options, please run `odoh-client bench --help`
+
+An example command for running the benchmark is as follows:
+
+```sh
+odoh-client bench --data dataset/tranco-1m.csv --target odoh.cloudflare-dns.com --proxy <instance> --out odoh-cf.json
+``` 
+
 ### Note
 
 > This tool includes a sub command for benchmarking various protocols and has been

--- a/commands/benchmark.go
+++ b/commands/benchmark.go
@@ -329,12 +329,14 @@ func benchmarkClient(c *cli.Context) {
 		log.Fatal("Failed to encode results:", err)
 	}
 
-	if _, err := os.Stat(outputFilePath); os.IsNotExist(err) {
-		fmt.Println(string(encResponses))
-	} else {
-		err = ioutil.WriteFile("output.json", encResponses, 0644)
-		if err != nil {
-			log.Fatal("Failed writing results to file:", err)
+	if outputFilePath != "" {
+		if _, err := os.Stat(outputFilePath); os.IsNotExist(err) {
+			err = ioutil.WriteFile(outputFilePath, encResponses, 0644)
+			if err != nil {
+				log.Fatal("Failed writing results to file:", err)
+			}
 		}
+	} else {
+		fmt.Println(string(encResponses))
 	}
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -111,6 +111,7 @@ var Commands = []cli.Command{
 			cli.StringFlag{
 				Name:  "out",
 				Value: "",
+				Usage: "Filename to save serialized JSON response from benchmark execution (eg. output.json). If no filename is provided, the default will print to console.",
 			},
 			cli.StringFlag{
 				Name:  "target",

--- a/fetch-datasets.sh
+++ b/fetch-datasets.sh
@@ -1,0 +1,55 @@
+set +eax
+
+DATASET_DIRECTORY=dataset
+if [ -d "$DATASET_DIRECTORY" ]
+then
+  echo "$DATASET_DIRECTORY directory exists and is not going to be created again."
+else
+  echo "$DATASET_DIRECTORY directory does not exist. Creating directory as necessary."
+  mkdir -p $DATASET_DIRECTORY
+fi
+
+TRANCO_DATASET_URL="https://tranco-list.eu/download/WXW9/1000000"
+TRANCO_DATASET_FILE="tranco-1m.csv"
+if [ -e "$DATASET_DIRECTORY/$TRANCO_DATASET_FILE" ]
+then
+  echo "$TRANCO_DATASET_FILE exists and will not be downloaded again"
+else
+  echo "$TRANCO_DATASET_FILE does not exist and needs to be downloaded."
+  read -p "Do you want to download the file now (y|Y|n|N) : " response
+  if [[ $response == 'Y' || $response == 'y' ]]
+  then
+    echo "Fetching the Tranco dataset from $TRANCO_DATASET_URL"
+    CURL_OK=true
+    WGET_OK=true
+    if ! command -v curl &> /dev/null
+    then
+        echo "curl could not be found. Proceeding to check for wget"
+        CURL_OK=false
+    fi
+    if ! command -v curl &> /dev/null
+    then
+        echo "wget could not be found. Aborting. Please install curl/wget"
+        WGET_OK=false
+    fi
+    echo "Command Exists [curl] $CURL_OK"
+    echo "Command Exists [wget] $WGET_OK"
+    if [[ $CURL_OK == true || $WGET_OK == true ]]
+    then
+      if [[ $CURL_OK == true ]]
+      then
+        curl $TRANCO_DATASET_URL --output "$DATASET_DIRECTORY/$TRANCO_DATASET_FILE"
+      else
+        wget -O "$DATASET_DIRECTORY/$TRANCO_DATASET_FILE" $TRANCO_DATASET_URL
+      fi
+      echo "File Download Complete and saved at $DATASET_DIRECTORY/$TRANCO_DATASET_FILE"
+      awk -F, '{printf "%s\n", $2}' $DATASET_DIRECTORY/$TRANCO_DATASET_FILE > $DATASET_DIRECTORY/$TRANCO_DATASET_FILE.awk
+      # Those terrible CR LF
+      sed $'s/\r//' $DATASET_DIRECTORY/$TRANCO_DATASET_FILE.awk > $DATASET_DIRECTORY/$TRANCO_DATASET_FILE.sed
+      mv $DATASET_DIRECTORY/$TRANCO_DATASET_FILE.sed $DATASET_DIRECTORY/$TRANCO_DATASET_FILE
+      rm $DATASET_DIRECTORY/$TRANCO_DATASET_FILE.awk
+    fi
+  else
+    echo "Aborting and not fetching the Tranco dataset"
+  fi
+fi


### PR DESCRIPTION
- Updates the ease with which benchmarks can be run
- Makes corrections to the `--out` benchmark output
- Adds scripts to download, and prepare dataset (Tranco) as an example

Signed-off-by: Sudheesh Singanamalla <sudheesh@cs.washington.edu>