### PR TITLE
Add CLI flag for providing ODoHConfigs directly.

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -48,6 +48,10 @@ var Commands = []cli.Command{
 				Name:  "proxy, p",
 				Usage: "Hostname:Port format declaration of the proxy hostname",
 			},
+			cli.StringFlag{
+				Name:  "config, c",
+				Usage: "ODoHConfigs to use for the query, encoded as a hexadecimal string",
+			},
 		},
 	},
 	{

--- a/commands/request.go
+++ b/commands/request.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 
 	odoh "github.com/cloudflare/odoh-go"
 	"github.com/miekg/dns"

--- a/commands/request.go
+++ b/commands/request.go
@@ -128,7 +128,7 @@ func obliviousDnsRequest(c *cli.Context) error {
 
 	var odohConfigs odoh.ObliviousDoHConfigs
 	var err error
-	if len(configString) == 0 {
+	if len(strings.TrimSpace(configString)) == 0 {
 		odohConfigs, err = fetchTargetConfigs(targetName)
 		if err != nil {
 			return err

--- a/commands/request.go
+++ b/commands/request.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -118,20 +119,34 @@ func obliviousDnsRequest(c *cli.Context) error {
 	dnsTypeString := c.String("dnstype")
 	targetName := c.String("target")
 	proxy := c.String("proxy")
+	configString := c.String("config")
 
 	var useproxy bool
 	if len(proxy) > 0 {
 		useproxy = true
 	}
 
-	odohConfigs, err := fetchTargetConfigs(targetName)
-	if err != nil {
-		return err
-	}
-	if len(odohConfigs.Configs) == 0 {
-		err := errors.New("target provided no valid odoh configs")
-		fmt.Println(err)
-		return err
+	var odohConfigs odoh.ObliviousDoHConfigs
+	var err error
+	if len(configString) == 0 {
+		odohConfigs, err = fetchTargetConfigs(targetName)
+		if err != nil {
+			return err
+		}
+		if len(odohConfigs.Configs) == 0 {
+			err := errors.New("target provided no valid odoh configs")
+			fmt.Println(err)
+			return err
+		}
+	} else {
+		configBytes, err := hex.DecodeString(configString)
+		if err != nil {
+			return err
+		}
+		odohConfigs, err = odoh.UnmarshalObliviousDoHConfigs(configBytes)
+		if err != nil {
+			return err
+		}
 	}
 	odohConfig := odohConfigs.Configs[0]
 


### PR DESCRIPTION
This was useful in testing targets across key rotation intervals (old but still structurally sound configs should fail to work), so I figured we could include it here. 